### PR TITLE
Bump @mcr.microsoft.com/dotnet/sdk from 6.0 to 7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: cimg/base:stable-18.04
   dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:7.0
 
 jobs:
   test:


### PR DESCRIPTION
Bump @mcr.microsoft.com/dotnet/sdk from 6.0 to 7.0